### PR TITLE
DIY quick start improvements

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -4,6 +4,8 @@
 This guide walks through training and serving bandit models.
 
 ## Installation
+banditml requires Python (>= 3.8).
+
 Clone the repo & install the requirements:
 ```
 git clone https://github.com/banditml/banditml.git
@@ -55,6 +57,23 @@ Sample records:
 Rewards can be `immediate` (e.g. a click on something recommeded) or `delayed` (e.g. a user purchases something you previously recommended at the end of a session after some browsing and after other decisions have been made). In the `rewards` table we handle both of these types of reward and use the following convention to distinguish them. `immedate` rewards should be logged with both a `decision_id` and a `decision` (e.g. rows `1` and `2` above). These reward rows are simply joined to their corresponding rows in the `decisions table`. `delayed` rewards should be logged without a `decision_id` and `decision` (e.g. row `3` above). `delayed` rewards should have keys in `metrics` that correspond to decisions previously made throughout the MDP. banditml joins these delayed rewards to the correct corresponding rows in the `decisions` table based on the `mdp_id` and where those specific decisions were chosen throughout the MDP.
 
 In the example above, `decision_id` `c2aa520f` would get an additional `10.5` reward at training time as we have a matching delayed reward in row `3` based on `mdp_id` and key `1` in `metrics`.
+
+## Loading data
+The schemas of the 2 BigQuery tables can be found in [scripts/schemas](scripts/schemas).  
+To create the two tables, run:
+
+```
+ python scripts/create_bq_tables.py \
+     --project=[MY_GCP_PROJECT]
+```
+Use `--help` to see all the GCP related parameters that can be defined.
+
+To load some dummy data, run:
+```
+ python scripts/write_height_dataset_to_bq.py \
+     --project=[MY_GCP_PROJECT]
+```
+Use `--help` to see all the GCP related parameters that can be defined. 
 
 ## Training a model
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -66,10 +66,10 @@ Then, to train a model simply run:
  python -m workflows.train_bandit \
      --params_path configs/bandit.json \
      --experiment_config_path configs/example_experiment_config.json \
-     --model_path trained_models/model.pkl
+     --predictor_save_dir trained_models
 ```
 
-This saves a model `model.pkl` in `trained_models`.
+This saves model artefacts `model_v1.json` and `model_v1.pt` in `trained_models/test-experiment-height-prediction-v8`.
 
 ## Serving a model
 

--- a/data_reader/bandit_reader.py
+++ b/data_reader/bandit_reader.py
@@ -30,9 +30,7 @@ class BigQueryReader:
         else:
             credentials = None
             project_id = None
-        self.client = bigquery.Client(
-            credentials=credentials, project=project_id
-        )
+        self.client = bigquery.Client(credentials=credentials, project=project_id)
         self.decisions_table_name = decisions_table_name
         self.rewards_table_name = rewards_table_name
         self.decisions_ds_start = decisions_ds_start

--- a/data_reader/bandit_reader.py
+++ b/data_reader/bandit_reader.py
@@ -2,6 +2,7 @@ import pandas as pd
 from google.cloud import bigquery
 from google.oauth2 import service_account
 from retry import retry
+from typing import Optional
 
 from utils.utils import get_logger
 
@@ -12,7 +13,7 @@ logger = get_logger(__name__)
 class BigQueryReader:
     def __init__(
         self,
-        credential_path: str,
+        credential_path: Optional[str],
         decisions_table_name: str,
         rewards_table_name: str,
         decisions_ds_start: str,
@@ -20,12 +21,17 @@ class BigQueryReader:
         rewards_ds_end: str,
         experiment_id: str,
     ):
-        credentials = service_account.Credentials.from_service_account_file(
-            filename=credential_path,
-            scopes=["https://www.googleapis.com/auth/cloud-platform"],
-        )
+        if credential_path:
+            credentials = service_account.Credentials.from_service_account_file(
+                filename=credential_path,
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+            project_id = credentials.project_id
+        else:
+            credentials = None
+            project_id = None
         self.client = bigquery.Client(
-            credentials=credentials, project=credentials.project_id
+            credentials=credentials, project=project_id
         )
         self.decisions_table_name = decisions_table_name
         self.rewards_table_name = rewards_table_name

--- a/scripts/create_bq_tables.py
+++ b/scripts/create_bq_tables.py
@@ -70,11 +70,12 @@ def create_table(
 
 def main(args) -> None:
     """Create BigQuery tables"""
-    credentials = (
-        service_account.Credentials.from_service_account_file(args.creds_path)
-        if args.creds_path
-        else None
-    )
+    if args.creds_path:
+        credentials = service_account.Credentials.from_service_account_file(
+            args.creds_path
+        )
+    else:
+        credentials = None
     client = bigquery.Client(project=args.project, credentials=credentials)
     create_dataset(
         client, args.dataset, args.dataset_description, args.dataset_location

--- a/scripts/create_bq_tables.py
+++ b/scripts/create_bq_tables.py
@@ -24,7 +24,7 @@ REWARDS_TABLE = "rewards"
 
 
 def create_dataset(
-        client: bigquery.Client, dataset_id: str, description: str, location: str
+    client: bigquery.Client, dataset_id: str, description: str, location: str
 ) -> None:
     """Creates a dataset in GCP.
 
@@ -42,11 +42,16 @@ def create_dataset(
         client.create_dataset(dataset)
         print("Created dataset {}.{}".format(client.project, dataset_id))
     except gexceptions.Conflict:
-        print("Dataset {} already existing in project {}. Skipping dataset creation...".format(dataset_id,
-                                                                                               client.project))
+        print(
+            "Dataset {} already existing in project {}. Skipping dataset creation...".format(
+                dataset_id, client.project
+            )
+        )
 
 
-def create_table(client: bigquery.Client, dataset_id: str, table_id: str, fields: List[Dict]):
+def create_table(
+    client: bigquery.Client, dataset_id: str, table_id: str, fields: List[Dict]
+):
     dataset = bigquery.Dataset("{}.{}".format(client.project, dataset_id))
     table_ref = dataset.table(table_id)
     table = bigquery.Table(table_ref, schema=fields)
@@ -54,16 +59,26 @@ def create_table(client: bigquery.Client, dataset_id: str, table_id: str, fields
 
     try:
         table = client.create_table(table)
-        print("Created table {}.{}.{}".format(table.project, table.dataset_id, table.table_id))
+        print(
+            "Created table {}.{}.{}".format(
+                table.project, table.dataset_id, table.table_id
+            )
+        )
     except gexceptions.GoogleAPIError as e:
         print("Table {} could not be created: {}. Skipping...".format(table_id, e))
 
 
 def main(args) -> None:
     """Create BigQuery tables"""
-    credentials = service_account.Credentials.from_service_account_file(args.creds_path) if args.creds_path else None
+    credentials = (
+        service_account.Credentials.from_service_account_file(args.creds_path)
+        if args.creds_path
+        else None
+    )
     client = bigquery.Client(project=args.project, credentials=credentials)
-    create_dataset(client, args.dataset, args.dataset_description, args.dataset_location)
+    create_dataset(
+        client, args.dataset, args.dataset_description, args.dataset_location
+    )
 
     # create decision table
     with open("scripts/schemas/decisions.json") as decisions_schema:

--- a/scripts/create_bq_tables.py
+++ b/scripts/create_bq_tables.py
@@ -1,0 +1,127 @@
+"""
+Script to create BigQuery tables following schema.
+
+Default parameters used to sanity test Bandit ML model implementations.
+
+Usage:
+    python -m scripts/create_bq_tables.py
+"""
+
+import argparse
+import json
+
+import google.api_core.exceptions as gexceptions
+from google.cloud import bigquery
+from google.oauth2 import service_account
+
+from typing import Dict, List
+
+# temp code
+PROJECT = "gradient-decision"
+DATASET_ID = "gradient_app_staging"
+DECISION_TABLE = "decisions"
+REWARDS_TABLE = "rewards"
+
+
+def create_dataset(
+        client: bigquery.Client, dataset_id: str, description: str, location: str
+) -> None:
+    """Creates a dataset in GCP.
+
+    Args:
+        client: The client used to create the dataset. Client should have a project defined.
+        dataset_id: The dataset id of the dataset to create.
+        description: The description of the dataset to create.
+        location: The GCP location of the dataset to create.
+
+    """
+    dataset = bigquery.Dataset("{}.{}".format(client.project, dataset_id))
+    dataset.description = description
+    dataset.location = location
+    try:
+        client.create_dataset(dataset)
+        print("Created dataset {}.{}".format(client.project, dataset_id))
+    except gexceptions.Conflict:
+        print("Dataset {} already existing in project {}. Skipping dataset creation...".format(dataset_id,
+                                                                                               client.project))
+
+
+def create_table(client: bigquery.Client, dataset_id: str, table_id: str, fields: List[Dict]):
+    dataset = bigquery.Dataset("{}.{}".format(client.project, dataset_id))
+    table_ref = dataset.table(table_id)
+    table = bigquery.Table(table_ref, schema=fields)
+    table.time_partitioning = bigquery.table.TimePartitioning()  # partition by day
+
+    try:
+        table = client.create_table(table)
+        print("Created table {}.{}.{}".format(table.project, table.dataset_id, table.table_id))
+    except gexceptions.GoogleAPIError as e:
+        print("Table {} could not be created: {}. Skipping...".format(table_id, e))
+
+
+def main(args) -> None:
+    """Create BigQuery tables"""
+    credentials = service_account.Credentials.from_service_account_file(args.creds_path) if args.creds_path else None
+    client = bigquery.Client(project=args.project, credentials=credentials)
+    create_dataset(client, args.dataset, args.dataset_description, args.dataset_location)
+
+    # create decision table
+    with open("scripts/schemas/decisions.json") as decisions_schema:
+        fields = json.load(decisions_schema)
+        create_table(client, args.dataset, args.decisions_table, fields)
+
+    # create rewards table
+    with open("scripts/schemas/rewards.json") as rewards_schema:
+        fields = json.load(rewards_schema)
+        create_table(client, args.dataset, args.rewards_table, fields)
+
+    print("ML bandit dataset and tables created.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--project",
+        type=str,
+        help="The ID of the GCP project where to create the Bigquery tables.",
+        default=PROJECT,
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        help="Dataset id in which to create tables in BigQuery.",
+        default=DATASET_ID,
+    )
+    parser.add_argument(
+        "--decisions_table",
+        type=str,
+        help="Name of the decision table.",
+        default=DECISION_TABLE,
+    )
+    parser.add_argument(
+        "--rewards_table",
+        type=str,
+        help="Name of the rewards table.",
+        default=REWARDS_TABLE,
+    )
+    parser.add_argument(
+        "--creds_path",
+        type=str,
+        help="Path to a GCP credentials file",
+        required=False,  # current account is ok
+    )
+    parser.add_argument(
+        "--dataset_location",
+        type=str,
+        help="GCP location of the dataset.",
+        default="US",
+    )
+    parser.add_argument(
+        "--dataset_description",
+        type=str,
+        help="Description of the dataset. Only used if the dataset does not already exist.",
+        default="Bandit ML dataset.",
+    )
+
+    args = parser.parse_args()
+    main(args)

--- a/scripts/schemas/decisions.json
+++ b/scripts/schemas/decisions.json
@@ -1,0 +1,37 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "decision_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "context",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "decision",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "experiment_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "variation_id",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "mdp_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ts",
+    "type": "INTEGER"
+  }
+]

--- a/scripts/schemas/rewards.json
+++ b/scripts/schemas/rewards.json
@@ -1,0 +1,32 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "decision_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "decision",
+    "type": "INTEGER"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "metrics",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "experiment_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "mdp_id",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ts",
+    "type": "INTEGER"
+  }
+]

--- a/scripts/write_height_dataset_to_bq.py
+++ b/scripts/write_height_dataset_to_bq.py
@@ -63,11 +63,21 @@ NUM_GET_DECISION_CALLS = 10000
 
 def main(args):
     # initialize bigquery client
-    credentials = service_account.Credentials.from_service_account_file(args.creds_path) if args.creds_path else None
+    credentials = (
+        service_account.Credentials.from_service_account_file(args.creds_path)
+        if args.creds_path
+        else None
+    )
     client = bigquery.Client(project=args.project, credentials=credentials)
-    decision_table_immediate = client.get_table("{}.{}{}".format(args.dataset, args.decisions_table, IMMEDIATE_PARTITION))
-    reward_table_immediate = client.get_table("{}.{}{}".format(args.dataset, args.rewards_table, IMMEDIATE_PARTITION))
-    reward_table_delayed = client.get_table("{}.{}{}".format(args.dataset, args.rewards_table, DELAYED_PARTITION))
+    decision_table_immediate = client.get_table(
+        "{}.{}{}".format(args.dataset, args.decisions_table, IMMEDIATE_PARTITION)
+    )
+    reward_table_immediate = client.get_table(
+        "{}.{}{}".format(args.dataset, args.rewards_table, IMMEDIATE_PARTITION)
+    )
+    reward_table_delayed = client.get_table(
+        "{}.{}{}".format(args.dataset, args.rewards_table, DELAYED_PARTITION)
+    )
 
     # create decisions to insert into table
     decisions_to_insert, immediate_rewards_to_insert, end_of_mdp_rewards_to_insert = (
@@ -83,8 +93,8 @@ def main(args):
 
         mean_height_adjustment = (CURRENT_YEAR - year) * YEARLY_MEAN_CM_ADJUSTMENTS
         mu = (
-                CURRENT_HEIGHT_DISTRIBUTIONS[country][gender]["mean"]
-                - mean_height_adjustment
+            CURRENT_HEIGHT_DISTRIBUTIONS[country][gender]["mean"]
+            - mean_height_adjustment
         )
         sigma = CURRENT_HEIGHT_DISTRIBUTIONS[country][gender]["stddev"]
         height = np.random.normal(mu, sigma, 1)[0]

--- a/scripts/write_height_dataset_to_bq.py
+++ b/scripts/write_height_dataset_to_bq.py
@@ -63,11 +63,12 @@ NUM_GET_DECISION_CALLS = 10000
 
 def main(args):
     # initialize bigquery client
-    credentials = (
-        service_account.Credentials.from_service_account_file(args.creds_path)
-        if args.creds_path
-        else None
-    )
+    if args.creds_path:
+        credentials = service_account.Credentials.from_service_account_file(
+            args.creds_path
+        )
+    else:
+        credentials = None
     client = bigquery.Client(project=args.project, credentials=credentials)
     decision_table_immediate = client.get_table(
         "{}.{}{}".format(args.dataset, args.decisions_table, IMMEDIATE_PARTITION)

--- a/workflows/predict.py
+++ b/workflows/predict.py
@@ -15,13 +15,28 @@ import pickle
 import time
 import zipfile
 
-import pandas as pd
+import numpy as np
+from sklearn.preprocessing import scale
 
 from banditml_pkg.banditml.serving.predictor import BanditPredictor
 from utils.utils import get_logger
 
-
 logger = get_logger(__name__)
+
+
+def softmax(x):
+    e_x = np.exp(x - np.max(x))
+    return e_x / e_x.sum()
+
+
+def get_single_decision(decisions):
+    scores = np.ndarray.flatten(np.array(decisions['scores']))
+    scores = softmax(scale(scores, with_mean=False, with_std=True))
+
+    return {
+        'greedyranker_decision': decisions['ids'][np.argmax(scores)],
+        'softmaxranker_decision': decisions['ids'][np.random.choice(len(scores), p=scores)]
+    }
 
 
 def get_decisions(json_input, predictor, get_ucb_scores=False):
@@ -44,6 +59,8 @@ def main(args):
 
     logger.info(f"Prediction request took {round(time.time() - start, 5)} seconds.")
     logger.info(f"Predictions: {decisions}")
+    if args.get_exploration_decision:
+        logger.info(f"Single exploitation/exploration decision: {get_single_decision(decisions)}")
 
 
 if __name__ == "__main__":
@@ -51,5 +68,6 @@ if __name__ == "__main__":
     parser.add_argument("--predictor_dir", required=True, type=str)
     parser.add_argument("--model_name", required=True, type=str)
     parser.add_argument("--get_ucb_scores", action="store_true")
+    parser.add_argument("--get_exploration_decision", action="store_true")
     args = parser.parse_args()
     main(args)

--- a/workflows/predict.py
+++ b/workflows/predict.py
@@ -11,9 +11,7 @@ Usage:
 
 import argparse
 import json
-import pickle
 import time
-import zipfile
 
 import numpy as np
 from sklearn.preprocessing import scale
@@ -30,12 +28,14 @@ def softmax(x):
 
 
 def get_single_decision(decisions):
-    scores = np.ndarray.flatten(np.array(decisions['scores']))
+    scores = np.ndarray.flatten(np.array(decisions["scores"]))
     scores = softmax(scale(scores, with_mean=False, with_std=True))
 
     return {
-        'greedyranker_decision': decisions['ids'][np.argmax(scores)],
-        'softmaxranker_decision': decisions['ids'][np.random.choice(len(scores), p=scores)]
+        "greedyranker_decision": decisions["ids"][np.argmax(scores)],
+        "softmaxranker_decision": decisions["ids"][
+            np.random.choice(len(scores), p=scores)
+        ],
     }
 
 
@@ -57,10 +57,12 @@ def main(args):
     decisions = get_decisions(json_input, predictor, args.get_ucb_scores)
     end = time.time()
 
-    logger.info(f"Prediction request took {round(time.time() - start, 5)} seconds.")
+    logger.info(f"Prediction request took {round(end - start, 5)} seconds.")
     logger.info(f"Predictions: {decisions}")
     if args.get_exploration_decision:
-        logger.info(f"Single exploitation/exploration decision: {get_single_decision(decisions)}")
+        logger.info(
+            f"Single exploitation/exploration decision: {get_single_decision(decisions)}"
+        )
 
 
 if __name__ == "__main__":

--- a/workflows/train_bandit.py
+++ b/workflows/train_bandit.py
@@ -13,7 +13,7 @@ import os
 import time
 import shutil
 import sys
-from typing import Dict, List, NoReturn, Tuple
+from typing import Dict
 
 from skorch import NeuralNetRegressor
 import torch

--- a/workflows/train_bandit.py
+++ b/workflows/train_bandit.py
@@ -12,6 +12,7 @@ import json
 import os
 import time
 import shutil
+import sys
 from typing import Dict, List, NoReturn, Tuple
 
 from skorch import NeuralNetRegressor
@@ -106,6 +107,9 @@ def train(
     )
 
     raw_data = data_reader.get_training_data()
+    if len(raw_data) == 0:
+        logger.error(f"Got no raws of training data. Training aborted.")
+        sys.exit()
     logger.info(f"Got {len(raw_data)} rows of training data.")
     logger.info(raw_data.head())
 


### PR DESCRIPTION
Hello, 

This PR adds some resources that helped me get the demo up and running.

### BQ tables 
- `scripts/create_bq_tables.py`:  new script to create the BQ tables, partitioned by ingestion time
- `script/schemas`: Table schemas in json format for consistency and usage with other tools (Terraform, bq mk, BQ api)

### Demo data loading
- ingestion time partition is hardcoded to work with the demo experiment config dates in `example_experiment_config.json`.

### Other
- minor doc fixes
- doc for BQ setup scripts in DOCS.md
- training demo: stop if no data is obtained from BQ to avoid hard to understand error later
- GCP sa credential optional for BQ setup and training scripts. Use default service account by default. GCP related variables can be overridden by passing them as parameters.
- new argument in `workflows/predict.py` to draw a decision from the model scores (exploitation exploration decision). Greedy and softmax ranking.

Really not sure for the minimum python version, I took the one used in the CI. 
Project is recent so the doc about styling, code contributing and all is not there yet, so I did not spent too much time on these points. The code should pass black and should not add errors to flake8, but it may depend on your config of those tools.  