### PR TITLE
Mixture density networks

### DIFF
--- a/banditml_pkg/banditml/models/embed_dnn.py
+++ b/banditml_pkg/banditml/models/embed_dnn.py
@@ -1,6 +1,5 @@
 import math
 from typing import Dict, List
-
 import pandas as pd
 import torch
 import torch.nn as nn
@@ -50,6 +49,7 @@ class EmbedDnn(nn.Module):
         id_feature_order=[],
         embedding_info={},
         is_classification=False,
+        is_mdn=False,
     ) -> None:
         super().__init__()
         self.layers: nn.ModuleList = nn.ModuleList()
@@ -58,6 +58,7 @@ class EmbedDnn(nn.Module):
         self.use_batch_norm = use_batch_norm
         self.dropout_layers: nn.ModuleList = nn.ModuleList()
         self.use_dropout = dropout_ratio > 0.0
+        self.is_mdn = is_mdn
         self.layer_norm_ops: nn.ModuleList = nn.ModuleList()
         self.use_layer_norm = use_layer_norm
         self.feature_specs = feature_specs
@@ -67,6 +68,7 @@ class EmbedDnn(nn.Module):
         self.embeddings_idx_map = {}
         self.model_spec = {}
         self.is_classification = is_classification
+        self.mdn_layer = nn.ModuleList()
 
         assert len(layers) >= 2, "Invalid layer schema {} for network".format(layers)
 
@@ -85,6 +87,7 @@ class EmbedDnn(nn.Module):
                 )
 
         for i, layer in enumerate(layers[1:]):
+            
             self.layers.append(nn.Linear(layers[i], layer))
             if self.use_batch_norm:
                 self.batch_norm_ops.append(nn.BatchNorm1d(layers[i]))
@@ -95,6 +98,11 @@ class EmbedDnn(nn.Module):
                 # applying dropout to all layers except
                 # the input and the last output layer
                 self.dropout_layers.append(nn.Dropout(p=dropout_ratio))
+                
+            if self.is_mdn and i == (len(layers[1:]) - 1):
+                # appending a separate layer for the variance estimates
+                self.mdn_layer.append(nn.Linear(layers[i], layer))
+                
             gaussian_fill_w_gain(
                 self.layers[i].weight, self.activations[i], layers[i], min_std
             )
@@ -150,8 +158,16 @@ class EmbedDnn(nn.Module):
                 x = getattr(F, activation)(x)
             if self.use_dropout and i < len(self.dropout_layers):
                 x = self.dropout_layers[i](x)
+            if self.is_mdn and i == (len(self.activations)-2):
+                sigma = self.mdn_layer[0](x)
+                m = nn.ELU()
+                sigma = m(sigma) + 1.0
+
 
         if self.is_classification:
             x = F.softmax(x, dim=1)
+
+        if self.is_mdn:
+            x = torch.cat([x, sigma], dim=0)
 
         return x

--- a/tests/workflow/test_train_bandit.py
+++ b/tests/workflow/test_train_bandit.py
@@ -329,18 +329,16 @@ class TestTrainBandit(unittest.TestCase):
             model_name="mixture_density_network",
         )
         
-        old_data = Datasets.X_COUNTRY_AND_DECISION_ID_LIST["X_train"]
-        results = skorch_net.predict(old_data)
-        y_vals = Datasets.X_COUNTRY_AND_DECISION_ID_LIST["y_train"]
+        X0 = Datasets.X_COUNTRY_AND_DECISION_ID_LIST["X_train"]
+        preds = skorch_net.predict(X0)
+        Y0 = Datasets.X_COUNTRY_AND_DECISION_ID_LIST["y_train"]
         
-        b = skorch_net.batch_size
-        v = range(results.shape[0])
-        mu_est = [i for i in v if i//b %2==0]
-        var_est = [i for i in v if i//b %2==1] 
-        mse = np.mean((results[mu_est].flatten()-y_vals.numpy().flatten())**2)
+        b_size = skorch_net.batch_size
+        idx = range(preds.shape[0])
+        mu_est = [i for i in idx if i//b_size %2==0]
+        var_est = [i for i in idx if i//b_size %2==1] 
+        mse = np.mean((preds[mu_est].flatten()-Y0.numpy().flatten())**2)
 
         assert (
             mse < 25
         )
-
-    

--- a/tests/workflow/test_train_bandit.py
+++ b/tests/workflow/test_train_bandit.py
@@ -5,14 +5,8 @@ from tests.fixtures import Params, Datasets
 from utils import model_constructors, model_trainers
 from workflows import train_bandit
 
-
-# ==========================================
-# Jonathan added these
 import torch
 import numpy as np
-import sys
-np.set_printoptions(threshold=sys.maxsize)
-import pandas as pd
 
 class TestTrainBandit(unittest.TestCase):
     @classmethod
@@ -192,7 +186,7 @@ class TestTrainBandit(unittest.TestCase):
         )
 
         test_mse = skorch_net.history[-1]["valid_loss"]
-        print("[JONATHAN JOHANNEMANN DEBUG] MSE LOSS OF ORIGINAL IS:",test_mse)
+
         # make sure mse is better or close to out of the box GBDT & MLP
         # the GBDT doesn't need as much training so make tolerance more forgiving
         # also this is learning 2 embedding tables so need more training time
@@ -334,10 +328,6 @@ class TestTrainBandit(unittest.TestCase):
             hyperparams=self.model_params,
             model_name="mixture_density_network",
         )
-        
-        # ===================================================
-        #            Testing the output of MDN
-        # ===================================================
         
         old_data = Datasets.X_COUNTRY_AND_DECISION_ID_LIST["X_train"]
         results = skorch_net.predict(old_data)

--- a/utils/model_constructors.py
+++ b/utils/model_constructors.py
@@ -14,6 +14,7 @@ def build_pytorch_net(
     activations,
     input_dim,
     dropout_ratio=0.0,
+    is_mdn=False,
 ):
     """Build PyTorch model that will be fed into skorch training."""
 
@@ -38,6 +39,7 @@ def build_pytorch_net(
         "id_feature_order": id_feature_order,
         "embedding_info": embedding_info,
         "is_classification": is_classification,
+        "is_mdn": is_mdn,
     }
     return model_spec, EmbedDnn(**model_spec)
 

--- a/workflows/train_bandit.py
+++ b/workflows/train_bandit.py
@@ -48,7 +48,7 @@ def train(
     )
 
     raw_data = data_reader.get_training_data()
-    print(raw_data.head())
+
     if len(raw_data) == 0:
         logger.error(f"Got no raws of training data. Training aborted.")
         sys.exit()

--- a/workflows/train_bandit.py
+++ b/workflows/train_bandit.py
@@ -48,7 +48,7 @@ def train(
     )
 
     raw_data = data_reader.get_training_data()
-
+    print(raw_data.head())
     if len(raw_data) == 0:
         logger.error(f"Got no raws of training data. Training aborted.")
         sys.exit()


### PR DESCRIPTION
Hey all, would love some feedback on the diff when you have a moment! (Would prefer not to push anything to master just yet because I want to double check output using data other than the data found in unittest.)

**Primary Changes**

1. I created another non-negative, linear + ELU layer for the variance estimate portion of the mixture density network.
2. I overwrote the skorch loss to minimize the NLL when `mixture_density_network` is chosen as the model name.
3. Added the MDN-based UCB scores to Bandit Predictor.
4. Wrote a test case for MDN, the MSE of the mean estimates is on par with the same neural bandit test, and has reasonable S.E.'s.

**Comments/Questions**

1. The variance estimates are appended to the bottom of each batch of mean estimates. I don't love this and get around it by modding indices to extract mu vs. stddev. I tried a column-bind but for some reason the MDN doesn't seem to learn when I do that. Do you have a preference or recommendation on how to approach this if this is a good use of time to fix?

2. The MDN implementation currently only applies to regression. Any thoughts on what you'd like to see around a binary reward estimation problem?

Also open to additional suggestions & critiques! Hope you're doing well.